### PR TITLE
Re-release argo-rollouts 1.6.1

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v1.6.1
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.32.5-1-cap-init
+version: 2.32.5-2-cap-init
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:


### PR DESCRIPTION
Re-release #35 

(Includes chart publish fix #36)