### PR TITLE
bump: Update Argo Rollouts to security fix CR-26082

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v1.7.1-CR-24605
+appVersion: v1.7.2-CR-26082
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.37.3-1-v1.7.1-CR-24605
+version: 2.37.3-2-v1.7.2-CR-26082
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -19,7 +19,7 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Sync argo-rollouts with upstream v1.7.1
+      description: Sync argo-rollouts with upstream v1.7.2 plus security fixes
       links:
         - name: GitHub Release
-          url: https://github.com/codefresh-io/argo-rollouts/releases/tag/v1.7.1-CR-24605
+          url: https://github.com/codefresh-io/argo-rollouts/releases/tag/v1.7.2-cap-CR-26082

--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v1.7.2-CR-26082
+appVersion: v1.7.2-cap-CR-26082
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.37.3-2-v1.7.2-CR-26082
+version: 2.37.3-2-v1.7.2-cap-CR-26082
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:


### PR DESCRIPTION
New image for Argo Rollouts (Codefresh variant) was pushed in Quay

https://quay.io/repository/codefresh/argo-rollouts?tab=tags&tag=latest

Includes

- All changes of OSS from 1.7.1 to 1.7.2
- Extra security fixes just for the Codefresh runtime customers