### PR TITLE
fix: upgrade to 7.7.14-3-cap-2.13.3-2025.2.12-7bfd6c858

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump argo-cd to v2.13.3-2025.2.12-7bfd6c858 for CR-27378, CR-27377
+      description: bumped argo-cd to v2.13.3-2025.2.12-7bfd6c858 + redis to 7.4.2 + bumped go-git for security fix  

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: bumped argo-cd to v2.13.3-2025.2.12-7bfd6c858 + redis to 7.4.2 + bumped go-git for security fix  
+      description: bumped argo-cd to v2.13.3-2025.2.12-7bfd6c858 + redis to 7.4.2 + bumped go-git for security fix

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: v2.13.3-2025.1.16-39ce1d3d0
+appVersion: v2.13.3-2025.2.12-7bfd6c858
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.7.14-2-cap-2.13.3-2025.1.16-39ce1d3d0
+version: 7.7.14-3-cap-2.13.3-2025.2.12-7bfd6c858
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Bump argo-cd to v2.13.3-2025.1.16-39ce1d3d0 for CR-26877
+      description: Bump argo-cd to v2.13.3-2025.2.12-7bfd6c858 for CR-27378, CR-27377

--- a/charts/argo-cd/README.md
+++ b/charts/argo-cd/README.md
@@ -1395,7 +1395,7 @@ NAME: my-release
 | redis.extraContainers | list | `[]` | Additional containers to be added to the redis pod |
 | redis.image.imagePullPolicy | string | `""` (defaults to global.image.imagePullPolicy) | Redis image pull policy |
 | redis.image.repository | string | `"public.ecr.aws/docker/library/redis"` | Redis repository |
-| redis.image.tag | string | `"7.4.1-alpine"` | Redis tag |
+| redis.image.tag | string | `"7.4.2-alpine"` | Redis tag |
 | redis.imagePullSecrets | list | `[]` (defaults to global.imagePullSecrets) | Secrets with credentials to pull images from a private registry |
 | redis.initContainers | list | `[]` | Init containers to add to the redis pod |
 | redis.livenessProbe.enabled | bool | `false` | Enable Kubernetes liveness probe for Redis server |
@@ -1481,7 +1481,7 @@ The main options are listed here:
 | redis-ha.haproxy.tolerations | list | `[]` | [Tolerations] for use with node taints for haproxy pods. |
 | redis-ha.hardAntiAffinity | bool | `true` | Whether the Redis server pods should be forced to run on separate nodes. |
 | redis-ha.image.repository | string | `"public.ecr.aws/docker/library/redis"` | Redis repository |
-| redis-ha.image.tag | string | `"7.4.1-alpine"` | Redis tag |
+| redis-ha.image.tag | string | `"7.4.2-alpine"` | Redis tag |
 | redis-ha.persistentVolume.enabled | bool | `false` | Configures persistence on Redis nodes |
 | redis-ha.redis.config | object | See [values.yaml] | Any valid redis config options in this section will be applied to each server (see `redis-ha` chart) |
 | redis-ha.redis.config.save | string | `'""'` | Will save the DB if both the given number of seconds and the given number of write operations against the DB occurred. `""`  is disabled |

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1291,7 +1291,7 @@ redis:
     # -- Redis repository
     repository: public.ecr.aws/docker/library/redis
     # -- Redis tag
-    tag: 7.4.1-alpine
+    tag: 7.4.2-alpine
     # -- Redis image pull policy
     # @default -- `""` (defaults to global.image.imagePullPolicy)
     imagePullPolicy: ""
@@ -1577,7 +1577,7 @@ redis-ha:
     # -- Redis repository
     repository: public.ecr.aws/docker/library/redis
     # -- Redis tag
-    tag: 7.4.1-alpine
+    tag: 7.4.2-alpine
   ## Prometheus redis-exporter sidecar
   exporter:
     # -- Enable Prometheus redis-exporter sidecar


### PR DESCRIPTION
2 security tickets:

1. https://codefresh-io.atlassian.net/browse/CR-27377 (bump redis to 7.4.2)
2. https://codefresh-io.atlassian.net/browse/CR-27378 (bump go-git to 5.13.1)

2 GitHub Actions release bumps:
1. actions/download-artifact bump
2. actions/upload-artifact bump