### PR TITLE
feat: update Argo CD to v2.14.9-2025-04-23-4de04dd8

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: v2.14.9-2025-04-20-584fc7f3
+appVersion: v2.14.9-2025-04-23-4de04dd8
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.8.23-1-cap-v2.14.9-2025-04-20-584fc7f3
+version: 7.8.23-2-cap-v2.14.9-2025-04-23-4de04dd8
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -65,7 +65,7 @@ global:
     # -- If defined, a repository applied to all Argo CD deployments
     repository: quay.io/codefresh/argocd
     # -- Overrides the global Argo CD image tag whose default is the chart appVersion
-    tag: "v2.14.9-2025-04-23-4de04dd8"
+    tag: ""
     # -- If defined, a imagePullPolicy applied to all Argo CD deployments
     imagePullPolicy: IfNotPresent
 

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -65,7 +65,7 @@ global:
     # -- If defined, a repository applied to all Argo CD deployments
     repository: quay.io/codefresh/argocd
     # -- Overrides the global Argo CD image tag whose default is the chart appVersion
-    tag: ""
+    tag: "v2.14.9-2025-04-23-4de04dd8"
     # -- If defined, a imagePullPolicy applied to all Argo CD deployments
     imagePullPolicy: IfNotPresent
 


### PR DESCRIPTION
[fix(appset): generated app errors should use the default requeue (#21887)](https://github.com/codefresh-io/argo-cd/pull/390)
