### PR TITLE
chore(argo-workflows): bump argo-workflows chart to v3.6.7-cap-CR-28355 and sync upstream/main

### DIFF
--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -16,10 +16,7 @@ annotations:
     fingerprint: 2B8F22F57260EFA67BE1C5824B11F800CD9D2252
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
-<<<<<<< HEAD
     - kind: changed
-      description: Add default global tolerations and nodeSelector
-=======
+      description: Bump argo-workflows to v3.6.7-cap-CR-28355
     - kind: fixed
       description: Restart server when configMap is updated
->>>>>>> upstream/main


### PR DESCRIPTION
…55 and sync upstream/main

lint