### PR TITLE
feat: bumped argocd to v2.14.9-2025-05-29-397c4f0d

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: bumped Argo CD version to v2.14.9-2025-05-29-397c4f0d
+      description: bumped Argo CD version to v2.14.9-2025-05-29-397c4f0d with mitigated GHSA-2hj5-g64g-fp6p

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: v2.14.9-2025-05-20-9356e64a
+appVersion: v2.14.9-2025-05-29-397c4f0d
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 7.8.23-6-cap-v2.14.9-2025-05-20-9356e64a
+version: 7.8.23-7-cap-v2.14.9-2025-05-29-397c4f0d
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: bumped Dex to v2.43.0
+      description: bumped Argo CD version to v2.14.9-2025-05-29-397c4f0d


### PR DESCRIPTION
Mitigated ghsa 2hj5 g64g fp6p:
https://github.com/codefresh-io/argo-cd/pull/398