### PR TITLE
chore: update upstream argo-cd 3.0.2 and bump helm chart to 8.0.6

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: v3.0.2-2025-05-20-6e4ca196
+appVersion: v3.0.2-2025-06-19-44e87762
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 8.0.6-0-cap-v3.0.2-2025-05-20-6e4ca196
+version: 8.0.6-1-cap-v3.0.2-2025-06-19-44e87762
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Synced argo-cd helm chart base v8.0.6 and argo-cd v3.0.2-2025-05-20-6e4ca196
+      description: Synced argo-cd helm chart base v8.0.6 and argo-cd v3.0.2-2025-06-19-44e87762


### PR DESCRIPTION
second PR (after #152). This one includes argo-cd version with fix for application destination query