### PR TITLE
feat: fixed CVEs related to webhook and repository credentials

### DIFF
--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: v3.1.5-2025-09-29-51be43f7
+appVersion: v3.1.5-2025-10-21-b3254810
 kubeVersion: ">=1.25.0-0"
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 8.0.6-11-cap-v3.1.5-2025-09-29-51be43f7
+version: 8.0.6-12-cap-v3.1.5-2025-10-21-b3254810
 home: https://github.com/argoproj/argo-helm
 icon: https://argo-cd.readthedocs.io/en/stable/assets/logo.png
 sources:
@@ -27,4 +27,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: backport monorepocontroller annotations to acr controller
+      description: fixed CVEs related to webhook and repository credentials


### PR DESCRIPTION
https://github.com/codefresh-io/argo-cd/pull/434

**CVEs:** 
CVSS 7.5 (high) [Unauthenticated argocd-server panic via a malicious Bitbucket-Server webhook payload](https://github.com/argoproj/argo-cd/security/advisories/GHSA-f9gq-prrc-hrhc)
CVSS 7.5 (high) [Unauthenticated Remote DoS in Argo CD via malformed Azure DevOps git.push webhook](https://github.com/argoproj/argo-cd/security/advisories/GHSA-gpx4-37g2-c8pv)
CVSS 7.5 (high) [Unauthenticated DoS due to lack of validation on pointer types](https://github.com/argoproj/argo-cd/security/advisories/GHSA-wp4p-9pxh-cgx2)
CVSS 6.5 (medium) [Repository Credentials Race Condition Crashes Argo CD Server](https://github.com/argoproj/argo-cd/security/advisories/GHSA-g88p-r42r-ppp9)