### PR TITLE
chore: security fixes for k8s client in Argo Rollouts v1.7.2

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Security fixes for Argo Rollouts v1.7.2 k8s client 
+      description: Security fixes for Argo Rollouts v1.7.2 k8s client

--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v1.7.2-cap-OSS-697
+appVersion: v1.7.2-cap-CR-31756
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.37.3-7-v1.7.2-cap-OSS-697
+version: 2.37.3-8-v1.7.2-cap-CR-31756
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Security fixes for Argo Rollouts v1.7.2 golang/x/net and cloudflare/circl
+      description: Security fixes for Argo Rollouts v1.7.2 k8s client 


### PR DESCRIPTION
Updated k8s client to 1.31.12 to address a CVE