### PR TITLE
chore: security fixes for k8s client  and golang in Argo Rollouts v1.7.2

### DIFF
--- a/charts/argo-rollouts/Chart.yaml
+++ b/charts/argo-rollouts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: v1.7.2-cap-CR-31756
+appVersion: v1.7.2-cap-CR-37067
 description: A Helm chart for Argo Rollouts
 name: argo-rollouts
-version: 2.37.3-8-v1.7.2-cap-CR-31756
+version: 2.37.3-9-v1.7.2-cap-CR-37067
 home: https://github.com/argoproj/argo-helm
 icon: https://argoproj.github.io/argo-rollouts/assets/logo.png
 keywords:
@@ -19,4 +19,4 @@ annotations:
     url: https://argoproj.github.io/argo-helm/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: changed
-      description: Security fixes for Argo Rollouts v1.7.2 k8s client
+      description: Security fixes for Argo Rollouts v1.7.2 Golang and k8s client


### PR DESCRIPTION
Updated k8s client to 1.34 and golang to 1.24 to address multiple CVE